### PR TITLE
詐欺の診断結果からの詐欺詳細情報を余計に生成しない処理

### DIFF
--- a/app/controllers/fraud_reports_controller.rb
+++ b/app/controllers/fraud_reports_controller.rb
@@ -30,13 +30,33 @@ class FraudReportsController < ApplicationController
             対話型の返答は省き、詐欺名(悪質商法も含む)のみを返答してください。
             PROMPT
 
+            response = ChatgptService.call(prompt) # ここで設定したAPIのメソッドを使っている
+            Rails.logger.info "ChatGPT API response: #{response}"
+            @fraud_report.respond = response # respondカラムという保存先を指定
+
+
+            # まず、詐欺診断処理を行って詐欺情報を確定させる
+            scam = handle_scam_diagnosis(response)
+
+            if scam.nil?
+              redirect_to root_path, alert: '詐欺情報の生成に失敗しました。'
+              return
+            end
+
+            # ここで `FraudReport` に `scam_id` を設定します
+            @fraud_report.scam = scam
+
+
         begin # エラーが出そうな部分を指定。
-            responce = ChatgptService.call(prompt) # ここで設定したAPIのメソッドを使っている
-            logger.info "OpenAI API response: #{response}" # レスポンスをログに出力
-                @fraud_report.respond = responce # respondカラムという保存先を指定
+            # response = ChatgptService.call(prompt) # ここで設定したAPIのメソッドを使っている
+            # Rails.logger.info "ChatGPT API response: #{response}"
+            #     @fraud_report.respond = response # respondカラムという保存先を指定
+
                 if @fraud_report.save
+                    # handle_scam_diagnosis(response) # 診断結果をscamテーブルに情報があるかチェック
                     redirect_to fraud_report_path(@fraud_report), notice: '診断名を受け取りました'
                 else
+                    logger.error "Failed to save fraud_report: #{@fraud_report.errors.full_messages.join(', ')}"
                     redirect_to root_path, alert: '保存に失敗しました。'
                 end
             rescue Net::ReadTimeout, StandardError => e # beginの箇所で失敗した場合のエラーをキャッチして処理
@@ -45,13 +65,39 @@ class FraudReportsController < ApplicationController
         end
     end
 
-    def show 
+    def show
         @fraud_report = FraudReport.find(params[:id])
+        @scam = Scam.find_by(name: @fraud_report.respond)
     end
 
   private
 
     def fraud_report_params
         params.require(:fraud_report).permit(:contact_method, :contact_content, :information, :urgent_action, :payment_method, :company_info, :additional_details)
+    end
+
+    def handle_scam_diagnosis(response_name)
+        scam = Scam.find_by(name: response_name)
+        return scam if scam
+
+        #ここに詐欺名がなかった場合の処理を記載
+        scam_content_prompt =
+                        <<~PROMPT
+                            詐欺名: #{response_name}
+                            上記の詐欺についての詳細を一言で教えてください。
+                            対話型の返答は省き、日本語で詐欺の詳細の1行だけを返答してください。
+                        PROMPT
+
+        scam_content = ChatgptService.call(scam_content_prompt)
+        Rails.logger.info "ChatGPT API response: #{scam_content}"
+        scam = Scam.new(name: response_name, content: scam_content)
+
+        if scam.save
+            Rails.logger.info "ChatGPT API response: #{scam_content}"
+            return scam
+        else
+            logger.error "Failed to save scam: #{scam.errors.full_messages.join(', ')}"
+            return nil
+        end
     end
 end

--- a/app/models/fraud_report.rb
+++ b/app/models/fraud_report.rb
@@ -1,2 +1,3 @@
 class FraudReport < ApplicationRecord
+    belongs_to :scam
 end

--- a/app/models/scam.rb
+++ b/app/models/scam.rb
@@ -1,0 +1,3 @@
+class Scam < ApplicationRecord
+    has_many :fraud_report
+end

--- a/app/views/fraud_reports/new.html.erb
+++ b/app/views/fraud_reports/new.html.erb
@@ -29,7 +29,7 @@
 
         <div class="w-full mb-4">
             <%= f.label :payment_method %>
-            <%= f.select :payment_method, options_for_select(["銀行振込", "ギフトカード", "暗号通貨", "その他"]), 
+            <%= f.select :payment_method, options_for_select(["銀行振込", "クレジットカード", "デビットカード", "モバイル決済(PayPayやApplepayなど)", "現金", "プリペイドカード", "ギフトカード", "暗号通貨", "その他"]), 
             { include_blank: "選択して下さい" }, class: "text-slate-950" %>
         </div>
 

--- a/app/views/fraud_reports/show.html.erb
+++ b/app/views/fraud_reports/show.html.erb
@@ -1,6 +1,8 @@
 <div class="flex-grow container mx-auto  flex flex-col items-center  text-orange">
     <div class="text-slate-950 text-6xl mt-20">
-    <%= @fraud_report.respond %>
+    <%= @scam.name %>
     </div>
     <P class="text-2xl mt-4">の可能性があります！</p>
+
+    <%= @scam.content %>
 </div>

--- a/db/migrate/20240615113352_create_scams.rb
+++ b/db/migrate/20240615113352_create_scams.rb
@@ -1,0 +1,10 @@
+class CreateScams < ActiveRecord::Migration[7.1]
+  def change
+    create_table :scams do |t|
+      t.string :name, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240615144821_add_scam_ref_to_fraud_reports.rb
+++ b/db/migrate/20240615144821_add_scam_ref_to_fraud_reports.rb
@@ -1,0 +1,5 @@
+class AddScamRefToFraudReports < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :fraud_reports, :scam, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_12_124448) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_15_144821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_12_124448) do
     t.string "respond"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "scam_id", null: false
+    t.index ["scam_id"], name: "index_fraud_reports_on_scam_id"
   end
 
+  create_table "scams", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "fraud_reports", "scams"
 end


### PR DESCRIPTION
- [ ] 詐欺情報を保存するscamテーブルを作成しました
- [ ] 詐欺名が診断されて詐欺情報を表示する時に、一旦scamテーブルをチェックするメソッドを記載しました
## チェック内容
- [ ]  scamテーブルに詐欺情報がない場合は詐欺情報を生成してscamテーブルに保存する処理
- [ ]  scamテーブルに詐欺情報があった場合はscamテーブルから詐欺情報を取得する処理
- [ ] 結論、詐欺診断結果や詐欺情報はAPIからの返答を受け取ったfraud_reportから表示せずに、scamテーブルから表示するようにしました。
### 下記画像は同じ詐欺名が生成されていない
[![Image from Gyazo](https://i.gyazo.com/e178d8d907ab67c7cce5f8b266e2dd3e.jpg)](https://gyazo.com/e178d8d907ab67c7cce5f8b266e2dd3e)
### かつ、scamテーブルから診断結果を表示していることを表すlogです
[![Image from Gyazo](https://i.gyazo.com/caad0b83c81c8ebe5769a8a18fb63ad2.jpg)](https://gyazo.com/caad0b83c81c8ebe5769a8a18fb63ad2)
# 行っていない実装
- [ ] scam_pointテーブルは作成していません。作成しないようにすると考えています
- [ ] なぜなら、scamテーブルのカラムを増やす方向で実装に問題ないと考えるからです。
- [ ]  まだ詐欺対策ポイントの再生や表示は行っていません。

close #30 