### PR TITLE
診断フォームをステップ式フォームにして対話型にしました

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,8 @@ import { application } from "./application"
 import FormController from "./form_controller"
 application.register("form", FormController)
 
-// 他のコントローラーも登録
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import StepFormController from "./step_form_controller"
+application.register("step-form", StepFormController)

--- a/app/javascript/controllers/step_form_controller.js
+++ b/app/javascript/controllers/step_form_controller.js
@@ -18,13 +18,31 @@ export default class extends Controller {
     });
   }
 
-  nextStep() {
-    if (this.currentStep < this.stepTargets.length) {
-      this.currentStep++;
-      this.showCurrentStep();
-    }
+  validateCurrentStep() {
+    const currentStepElement = this.stepTargets[this.currentStep - 1];
+    const radioGroups = currentStepElement.querySelectorAll('input[type="radio"]');
+    let isValid = false;
+
+    radioGroups.forEach((radio) => {
+      if (radio.checked) {
+        isValid = true;
+      }
+    });
+
+    return isValid;
   }
 
+  nextStep() {
+    if (this.validateCurrentStep()) {
+      if (this.currentStep < this.stepTargets.length) {
+        this.currentStep++;
+        this.showCurrentStep();
+      }
+    } else {
+      alert("選択してください");
+    }
+  }
+  
   prevStep() {
     if (this.currentStep > 1) {
       this.currentStep--;

--- a/app/javascript/controllers/step_form_controller.js
+++ b/app/javascript/controllers/step_form_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["step"]
+
+  connect() {
+    this.currentStep = 1; // 初期ステップを1に設定
+    this.showCurrentStep();
+  }
+
+  showCurrentStep() {
+    this.stepTargets.forEach((stepElement, index) => {
+      if (index === this.currentStep - 1) {
+        stepElement.style.display = "block"; // 現在のステップを表示
+      } else {
+        stepElement.style.display = "none"; // それ以外のステップを非表示
+      }
+    });
+  }
+
+  nextStep() {
+    if (this.currentStep < this.stepTargets.length) {
+      this.currentStep++;
+      this.showCurrentStep();
+    }
+  }
+
+  prevStep() {
+    if (this.currentStep > 1) {
+      this.currentStep--;
+      this.showCurrentStep();
+    }
+  }
+}

--- a/app/views/fraud_reports/new.html.erb
+++ b/app/views/fraud_reports/new.html.erb
@@ -1,8 +1,10 @@
 <div class="flex-grow container mx-auto flex flex-col items-center text-orange" data-controller="form">
     <p class="my-8 text-4xl">選択してください</p>
+  <div data-controller="step-form">
     <%= form_with model: @fraud_report do |f| %>
       <div class="text-xl">
-        <div class="w-full mb-4">
+        <div id="step1" style="display: block;" data-step-form-target="step">
+          <div class="w-full mb-4">
             <%= f.label :contact_method %>
             <div class="flex flex-wrap text-slate-950">
                 <%= f.radio_button :contact_method, "電話", id: "contact_method_phone", class: "js-check-method" %>
@@ -28,8 +30,11 @@
 
                 <span id="method"><%= f.text_field :contact_method, id: "contact_method_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
             </div>
+          <button type="button" data-action="step-form#nextStep" class="text-blue">次へ</button>
         </div>
+    </div>
 
+      <div id="step2" style="display: none;" data-step-form-target="step" >
         <div class="w-full mb-4">
             <%= f.label :contact_content %>
             <div class="flex flex-wrap text-slate-950">
@@ -64,12 +69,14 @@
                 <%= f.label :contact_content_other, "その他" %>
 
                 <span id="content"><%= f.text_field :contact_content, id: "contact_content_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
-            </div>
-        </div>
+              </div>
+                <button type="button" data-action="step-form#prevStep">戻る</button>
+                <button type="button" data-action="step-form#nextStep">次へ</button>
+          </div>
+      </div>
 
-
-
-        <div class="w-full mb-4">
+      <div id="step3" style="display: none;" data-step-form-target="step">
+          <div class="w-full mb-4">
             <%= f.label :information %>
             <div class="flex flex-wrap text-slate-950">
                 <%= f.radio_button :information, "個人情報(名前、住所、電話番号など)", id: "information_personal_info", class: "js-check-information" %>
@@ -98,8 +105,12 @@
 
                 <span id="information"><%= f.text_field :information, id: "information_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
             </div>
-        </div>
+                <button type="button" data-action="step-form#prevStep">戻る</button>
+                <button type="button" data-action="step-form#nextStep">次へ</button>
+          </div>
+      </div>
 
+      <div id="step4" style="display: none;" data-step-form-target="step">
         <div class="w-full mb-4">
             <%= f.label :urgent_action %>
             <div class="flex flex-wrap text-slate-950">
@@ -109,8 +120,12 @@
                 <%= f.radio_button :urgent_action, "いいえ", id: "urgent_action_no" %>
                 <%= f.label :urgent_action_no, "いいえ" %>
             </div>
+              <button type="button" data-action="step-form#prevStep">戻る</button>
+              <button type="button" data-action="step-form#nextStep">次へ</button>
         </div>
+      </div>
 
+      <div id="step5" style="display: none;" data-step-form-target="step">
         <div class="w-full mb-4">
             <%= f.label :payment_method %>
             <div class="flex flex-wrap text-slate-950">
@@ -131,8 +146,12 @@
 
                 <span id="payment"><%= f.text_field :information, id: "payment_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
             </div>
+            <button type="button" data-action="step-form#prevStep">戻る</button>
+            <button type="button" data-action="step-form#nextStep">次へ</button>
         </div>
+      </div>
 
+      <div id="step6" style="display: none;" data-step-form-target="step">
         <div class="w-full mb-4">
             <%= f.label :company_info %>
             <div class="flex flex-wrap text-slate-950">
@@ -142,8 +161,12 @@
                 <%= f.radio_button :company_info, "いいえ", id: "company_info_no" %>
                 <%= f.label :company_info_no, "いいえ" %>
             </div>
+            <button type="button" data-action="step-form#prevStep">戻る</button>
+            <button type="button" data-action="step-form#nextStep">次へ</button>
         </div>
+      </div>
 
+      <div id="step7" style="display: none;" data-step-form-target="step">
         <div class="w-full mb-4">
             <%= f.label :who_person %>
             <div class="flex flex-wrap text-slate-950">
@@ -175,10 +198,12 @@
                 <%= f.label :who_person_unknown, "具体的にはわからない" %>
             </div>
         </div>
-
-        <div class="w-full mb-4 mt-10 text-center btn w-64 rounded-full">
-            <%= f.submit "診断する" %>
+            <button type="button" data-action="step-form#prevStep">戻る</button>
+          <div class="w-full mb-4 mt-10 text-center btn w-64 rounded-full">
+              <%= f.submit "診断する" %>
+          </div>
         </div>
       </div>
     <% end %>
+  </div>
 </div>

--- a/app/views/fraud_reports/new.html.erb
+++ b/app/views/fraud_reports/new.html.erb
@@ -3,7 +3,6 @@
     <%= form_with model: @fraud_report do |f| %>
       <div class="text-xl">
         <div class="w-full mb-4">
-          <div data-controller="form">
             <%= f.label :contact_method %>
             <div class="flex flex-wrap text-slate-950">
                 <%= f.radio_button :contact_method, "電話", id: "contact_method_phone", class: "js-check-method" %>
@@ -29,11 +28,9 @@
 
                 <span id="method"><%= f.text_field :contact_method, id: "contact_method_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
             </div>
-          </div>
         </div>
 
         <div class="w-full mb-4">
-          <div data-controller="form">
             <%= f.label :contact_content %>
             <div class="flex flex-wrap text-slate-950">
                 <%= f.radio_button :contact_content, "投資の勧誘", id: "contact_content_investment", class: "js-check-content" %>
@@ -68,13 +65,11 @@
 
                 <span id="content"><%= f.text_field :contact_content, id: "contact_content_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
             </div>
-          </div>
         </div>
 
 
 
         <div class="w-full mb-4">
-          <div data-controller="form">
             <%= f.label :information %>
             <div class="flex flex-wrap text-slate-950">
                 <%= f.radio_button :information, "個人情報(名前、住所、電話番号など)", id: "information_personal_info", class: "js-check-information" %>
@@ -103,7 +98,6 @@
 
                 <span id="information"><%= f.text_field :information, id: "information_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
             </div>
-          </div>
         </div>
 
         <div class="w-full mb-4">
@@ -118,7 +112,6 @@
         </div>
 
         <div class="w-full mb-4">
-          <div data-controller="form">
             <%= f.label :payment_method %>
             <div class="flex flex-wrap text-slate-950">
                 <%= f.radio_button :payment_method, "なし", id: "payment_method_none", class: "js-check-payment" %>
@@ -138,7 +131,6 @@
 
                 <span id="payment"><%= f.text_field :information, id: "payment_text", disabled: true, required: true, placeholder: "具体的に表示してください" %></span>
             </div>
-          </div>
         </div>
 
         <div class="w-full mb-4">


### PR DESCRIPTION
- [ ] ステップ式フォームに実装しました。
- [ ] "次へ"で次のステップに行く前に、ラジオボタンが選択されていなかったら進めないようにバリデーションの実装もしました。

ステップ式フォーム
[![Image from Gyazo](https://i.gyazo.com/f9ab5c2f9eff4abb0631901be190ce16.gif)](https://gyazo.com/f9ab5c2f9eff4abb0631901be190ce16)

バリデーション
[![Image from Gyazo](https://i.gyazo.com/b0e19b03317027b494fee47f3f0b23a8.gif)](https://gyazo.com/b0e19b03317027b494fee47f3f0b23a8)

close #68 