### PR TITLE
マークダウン機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,4 +102,6 @@ gem 'ransack', '~> 4.0.0'
   gem 'sidekiq-scheduler'
 
 # gem 'dotenv-rails' install
-gem 'dotenv-rails'
+  gem 'dotenv-rails'
+# gem 'redcarpet' install
+  gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,7 @@ GEM
       i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     redis-client (0.22.2)
       connection_pool
     regexp_parser (2.9.2)
@@ -408,6 +409,7 @@ DEPENDENCIES
   rails (~> 7.0.8, >= 7.0.8.4)
   rails-i18n (~> 7.0.0)
   ransack (~> 4.0.0)
+  redcarpet
   rspec-rails
   rubocop (~> 1.64)
   rubocop-performance

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,31 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.markdown-body h1 {
+  @apply text-4xl font-bold;
+}
+.markdown-body h2 {
+  @apply text-2xl font-bold;
+}
+.markdown-body h3 {
+  @apply text-xl font-bold;
+}
+.markdown-body h4 {
+  @apply text-lg font-bold;
+}
+.markdown-body a {
+  @apply text-sky-500 border-b border-sky-500;
+}
+.markdown-body ul {
+  @apply list-disc list-inside;
+}
+.markdown-body hr {
+  @apply border-t-2 border-slate-400 w-full;
+}
+.markdown-body blockquote {
+  @apply p-2 border-s-4 border-gray-300 bg-gray-100 text-sm;
+}
+.markdown-body code {
+  @apply bg-red-200 font-normal text-base;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:user)
+    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
     @search_target = 'post'
   end
 

--- a/app/controllers/scams_controller.rb
+++ b/app/controllers/scams_controller.rb
@@ -2,7 +2,7 @@ class ScamsController < ApplicationController
 
     def index
         @q = Scam.ransack(params[:q])
-        @scams = @q.result(distinct: true)
+        @scams = @q.result(distinct: true).order(created_at: :desc)
         @search_target = 'scam'
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include MarkdownHelper
+  
     def flash_background_color(type)
       case type.to_sym
         when :notice then "bg-green-500"

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,26 @@
+module MarkdownHelper
+  def markdown(text)
+    unless @markdown
+      options = {
+      filter_html:     true,
+      hard_wrap:       true,
+      space_after_headers: true,
+      safe_links_only: true,
+    }
+
+    extensions = {
+      autolink:           true,
+      no_intra_emphasis:  true,
+      quote:              true,
+      strikethrough:      true,
+      codespan:           true,
+      superscript:        true,
+      fenced_code_blocks: true,
+    }
+      renderer = Redcarpet::Render::HTML.new(options)
+      @markdown = Redcarpet::Markdown.new(renderer, extensions)
+    end
+
+    @markdown.render(text).html_safe
+  end
+end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,9 +9,9 @@
 				<%= @post.users_scam_name %>
 			</div>
 			<div class="text-slate-950 text-xl my-10 px-4 py-2 border border-dashed border-gray-500 overflow-auto rounded h-48">
-				<% @post_body.each do |body|%>
-				<div class="flex">
-					<%= body %>
+			<% @post_body.each do |body| %>
+				<div class="markdown-body">
+				<%= markdown(body) %>
 				</div>
 				<% end %>
 			</div>


### PR DESCRIPTION
投稿に一部のマークダウン記法が反映されるように実装しました。
[![Image from Gyazo](https://i.gyazo.com/171210b565e91c38b6a4340791dd05c5.gif)](https://gyazo.com/171210b565e91c38b6a4340791dd05c5)

テーブルとチェックボックスは実装できませんでした。
コードブロックは技術記事ではないので実装しませんでした。