### PR TITLE
エラー解決

### DIFF
--- a/app/controllers/fraud_reports_controller.rb
+++ b/app/controllers/fraud_reports_controller.rb
@@ -105,7 +105,7 @@ class FraudReportsController < ApplicationController
             Rails.logger.info "ChatGPT API response: #{scam_strategy}"
 
         # scamオブジェクトを生成かつcreate_scamに保存
-            create_scam = Scam.new(name: response_name, content: scam_content, point_1: scam_point_1, point_2: scam_point_2, point_3: scam_point_3, scam_strategy: scam_strategy)
+            create_scam = Scam.new(name: response_name.strip, content: scam_content, point_1: scam_point_1, point_2: scam_point_2, point_3: scam_point_3, scam_strategy: scam_strategy)
                 if create_scam.save
                     Rails.logger.info "ChatGPT API response: #{scam_content}"
                     return create_scam


### PR DESCRIPTION
下記のエラーを解決するために、scamのnameを保存するときはstripメソッドをつけて空欄をなくしました
[![Image from Gyazo](https://i.gyazo.com/f64e5faf876ae09f5d8cdbe7f30dfbae.jpg)](https://gyazo.com/f64e5faf876ae09f5d8cdbe7f30dfbae)

close #171 